### PR TITLE
docker: fix home dir permissions

### DIFF
--- a/containers/dockerfiles/scanpy.Dockerfile
+++ b/containers/dockerfiles/scanpy.Dockerfile
@@ -27,6 +27,8 @@ COPY --chown="${NB_UID}:${NB_GID}" --chmod=0755 scripts/download-labs.sh ${HOME}
 
 USER ${NB_UID}
 
+RUN mkdir -p ${HOME}/work
+
 EXPOSE 8888
 
 ENTRYPOINT ["tini", "-g", "--", "./start-script.sh"]

--- a/containers/dockerfiles/seurat-bioc.Dockerfile
+++ b/containers/dockerfiles/seurat-bioc.Dockerfile
@@ -26,6 +26,8 @@ RUN chown -R jovyan:users ${HOME} \
 
 USER jovyan
 
+RUN mkdir -p ${HOME}/work
+
 WORKDIR ${HOME}
 
 EXPOSE 8787

--- a/containers/dockerfiles/seurat-bioc.Dockerfile
+++ b/containers/dockerfiles/seurat-bioc.Dockerfile
@@ -17,8 +17,12 @@ RUN /usr/local/conda/bin/conda-lock install \
     && /usr/local/conda/bin/conda clean --all -f -y
 
 # Configure container start
-COPY --chown="jovyan:users" --chmod=0755 scripts/seurat-start-script.sh ${HOME}/start-script.sh
-COPY --chown="jovyan:users" --chmod=0755 scripts/download-labs.sh ${HOME}/download-labs.sh
+COPY scripts/seurat-start-script.sh ${HOME}/start-script.sh
+COPY scripts/download-labs.sh ${HOME}/download-labs.sh
+
+RUN chown -R jovyan:users ${HOME} \
+    && chmod a+x ${HOME}/start-script.sh \
+    && chmod a+x ${HOME}/download-labs.sh
 
 USER jovyan
 

--- a/containers/scripts/download-labs.sh
+++ b/containers/scripts/download-labs.sh
@@ -1,8 +1,8 @@
 #! /bin/bash
 
 ## Example usage:
-#   ./download-labs.sh "https://github.com/NBISweden" "workshop-scRNAseq-devel" "compiled/labs" "seurat" "labs"
-#   ./download-labs.sh "https://github.com/NBISweden" "workshop-scRNAseq-devel" "compiled/labs" "scanpy" "labs"
+#   ./download-labs.sh "https://github.com/NBISweden" "workshop-scRNAseq" "compiled/labs" "seurat" "work/labs"
+#   ./download-labs.sh "https://github.com/NBISweden" "workshop-scRNAseq" "compiled/labs" "scanpy" "work/labs"
 
 orgurl="$1"
 reponame="$2"


### PR DESCRIPTION
This PR ensures that `/home/jovyan` has `jovyan:users` ownership (previously owned by `root:root`). It also adds an empty dir `/home/jovyan/work` intended for mounting the Serve volume. Mounting the volume to `/home/jovyan` might introduce unexpected behaviour.