### PR TITLE
fix/seurat: bash profile

### DIFF
--- a/containers/dockerfiles/seurat-bioc.Dockerfile
+++ b/containers/dockerfiles/seurat-bioc.Dockerfile
@@ -26,7 +26,9 @@ RUN chown -R jovyan:users ${HOME} \
 
 USER jovyan
 
-RUN mkdir -p ${HOME}/work
+RUN mkdir -p ${HOME}/work \
+    && chown -R jovyan:users ${HOME}
+    && cp ~/.bashrc ~/.bash_profile
 
 WORKDIR ${HOME}
 

--- a/containers/dockerfiles/seurat-bioc.Dockerfile
+++ b/containers/dockerfiles/seurat-bioc.Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/scilifelabdatacentre/serve-rstudio:231030-1146
+FROM ghcr.io/scilifelabdatacentre/serve-rstudio:250304-1611
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 


### PR DESCRIPTION
- Use latest serve image that has RStudio 2024.
- Fix the issue with RStudio terminal that doesn't source `.bashrc` by default.