### PR TITLE
docs: fix local scanpy

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Open in browser: `http://localhost:8787/`
 - To run Python labs in JupyterLab
 
 ```
-docker run --rm --platform=linux/amd64 -p 8888:8888 -v ${PWD}:/home/jovyan/work ghcr.io/nbisweden/workshop-scrnaseq-scanpy:20250325-2256
+docker run --rm --platform=linux/amd64 -p 8888:8888 -v ${PWD}:/home/jovyan/work/work ghcr.io/nbisweden/workshop-scrnaseq-scanpy:20250325-2256
 ```
 
 Open in browser: `http://localhost:8888/lab` and use password `scrnaseq`

--- a/other/containers.qmd
+++ b/other/containers.qmd
@@ -126,7 +126,7 @@ To avoid running out of memory, restart the kernel (_Kernel > Restart Kernel_) a
 ```
 cd /path/to/labs  # replace this with the full path to the workshop compiled lab folder
 docker pull --platform=linux/amd64 ghcr.io/nbisweden/workshop-scrnaseq-scanpy:20250325-2256
-docker run --platform=linux/amd64 --rm -p 8888:8888 -v ${PWD}:/home/jovyan/work ghcr.io/nbisweden/workshop-scrnaseq-scanpy:20250325-2256
+docker run --platform=linux/amd64 --rm -p 8888:8888 -v ${PWD}:/home/jovyan/work/work ghcr.io/nbisweden/workshop-scrnaseq-scanpy:20250325-2256
 ```
 
 Do not close the terminal! In the browser, go to [localhost:8888](localhost:8888/lab). Use the following credentials to log in to the JupyterLab server:  

--- a/other/docker.qmd
+++ b/other/docker.qmd
@@ -40,7 +40,7 @@ Visit [this page](https://docs.docker.com/desktop/install/windows-install/) to e
 
 Download [Docker Desktop for Windows](https://hub.docker.com/editions/community/docker-ce-desktop-windows) and follow the installation instructions. 
 
-After Docker Desktop starts, open the Dashboard and go to *Settings ({{< fa gear >}} in the top-right) > General*. Follow the [instructions](https://docs.docker.com/desktop/settings/windows//) in the _General_ section.
+After Docker Desktop starts, open the Dashboard and go to *Settings ({{< fa gear >}} in the top-right) > General*. Follow the [instructions](https://docs.docker.com/desktop/settings/windows/) in the _General_ section.
 
 After installation, open a PowerShell terminal and try to run `docker --version`. If that works, Docker is set up.
 


### PR DESCRIPTION
This PR fixes the `scanpy` mount path to run JupyterLab locally, so that it matches the setup in SciLifeLab Serve. It also fixes a broken link in the documentation to install Docker Desktop for Windows.