### PR TITLE
docs: add internal documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing
 
-To add or update contents of this repo, first clone the repo, create a new branch, make changes/updates as needed, stage the changes, commit it and push the new branch to GitHub. Then, on GitHub, send a pull request to master.
+To add or update contents of this repo, first clone the repo, create a new branch (name the branch according to the changes you are going to introduce), make changes/updates as needed, stage the changes, commit and push the new branch to GitHub. Then, on GitHub, open a pull request towards `master`.
 
 ```
 git clone --depth 1 --single-branch --branch master https://github.com/nbisweden/workshop-scrnaseq.git
@@ -13,24 +13,28 @@ git commit -m "short descriptive message"
 git push -u origin <branch_name>
 ```
 
-The labs use Quarto's _shortcodes_ for templating, with metadata located in `docs/labs/_metadata.yml`. These are snippets of text identified by a _tag_ of the form `{{< meta >}}` and allow to insert the same content to the different toolkits. The lab templates are stored in `docs/labs/<toolkit>`. To get the final version of the labs you need to compile the labs and the results are stored in `compiled/labs/<toolkit>`.
+The labs use Quarto's _shortcodes_ for templating, with metadata located in `docs/labs/_metadata.yml`. These are snippets of text identified by a _tag_ of the form `{{< meta >}}` that allow to insert the same content to the different toolkits. The lab templates are stored in `docs/labs/<toolkit>`. To get the final version of the labs you need to compile the labs and the results are stored in `compiled/labs/<toolkit>`.
 
 To make changes to the labs, the workflow is as follows:
-- Add/modify metedata snippets.
+- Add/modify metadata snippets.
 - Add the new snippet tag to all labs in `docs/labs`.
-- Add/modify code blocks in all toolkits.
-- Compile labs.
-- Test your changes.
+- Add/modify code blocks in each toolkit.
+- Compile the labs.
+- Test your changes on the compiled labs.
+- Render the site and serve it locally.
+- (_Course leaders only!_) Publish the site.
 
 Once all changes are tested, you need to [render the site](#render-site). This step takes `.qmd` files and renders `.html` files for the site. The site is located in `docs/_site`.
 
-> **IMPORTANT:** Before rendering any files, make sure `docs/_site` is synced with the contents of `gh-pages` branch. See [site](#site) section for more details.
+> **IMPORTANT:** Before rendering any files, make sure `docs/_site` is _synced_ with the contents of `gh-pages` branch. See [site](#site) section for more details.
+
+`docs/_site` folder is ignored by git. This means that it will be visible _as is_ in all your branches. This is important, because when the site is published, it is published from this location. In other words, this should reflect the content of `gh-pages` branch.
 
 ## Site
 
 This section contains guidelines on how to make changes to site-related files (_i.e._ `compiled/` and `docs/` folders). Read first the [suggested workflow](#suggested-workflow) section.
 
-> **IMPORTANT:** If you made changes to the labs (`docs/labs`) you need to [compile the labs](#compile-labs) first.
+> **IMPORTANT:** If you made changes to the labs (`docs/labs`) you need to [compile the labs](#compile-labs) first, before rendering the site.
 
 ### Suggested workflow
 
@@ -39,11 +43,11 @@ This section contains guidelines on how to make changes to site-related files (_
 - Switch back to the feature branch.
 - If you don't have a folder `docs/_site` you should create one.
   ```sh
-  mkdir docs/_site
+  mkdir -p docs/_site
   ```
 - If you already have a folder `docs/_site`, remove all its content (but not the folder itself).
   ```sh
-  rm -rf docs/_site/*
+  rm -rf docs/_site/.
   ```
 - Update the folder `docs/_site` with the content of `gh-pages` branch.
   ```sh
@@ -51,23 +55,22 @@ This section contains guidelines on how to make changes to site-related files (_
   ```
 - Verify that `docs/_site` on your feature branch is now up to date.
 - [Render](#render-site) any code files that were changed.
-- Serve the site locally and check the changes
+- Serve the site locally and check the changes by running the command below. Then in the browser, navigate to `localhost:8000`, and check the site content.
   ```sh
   cd docs/_site
   python3 -m http.server 8000
   ```
-- To serve the site from the feature branch (make sure the content is what you intend)
+- (_Course leaders only!_) From the `docs` folder, publish the content of `docs/_site`.
   ```sh
-  cd docs
+  cd ..  # $PROJECT_DIR/docs
   quarto publish gh-pages --no-render
   ```
-- You can follow the same procedure from `master` after you merged your feature branch.
 
-- **IMPORTANT:** This workflow works with `archive` as well, since we tar the `gh-pages` branch content, and as long as `gh-pages:archive` folder exists, it will be included in the tar, and copied to `docs/_site`. Rendering will not interfere with this folder.
+> **IMPORTANT:** This workflow works with `archive` as well, since we tar the `gh-pages` branch content, and as long as `gh-pages:archive` folder exists, it will be included in the tar, and copied to `docs/_site`. Rendering will not interfere with this folder.
 
 ### Compile labs
 
-To compile all `.qmd` into `compiled/labs` as `.qmd` and `.ipynb` with evaluated meta variables, can be run directly with the compile script using:
+To compile all `.qmd` into `compiled/labs` as `.qmd` or `.ipynb` with evaluated meta variables, can be achieved directly with the compile script:
 
 ```
 bash scripts/compile.sh [seurat|bioc|scanpy|all]
@@ -75,15 +78,15 @@ bash scripts/compile.sh [seurat|bioc|scanpy|all]
 
 ### Render site
 
-To render all `.qmd` files (site files and labs) in the repo to `docs/_site` as `.html` output, run the command below, choosing the corresponding argument, depending on your changes.
+To render `.qmd` files (site files as well as labs) in the repo to `docs/_site` as `.html` output, run the command below, choosing the corresponding argument, depending on your changes.
 
-> **WARNING:** Rendering the labs takes several minutes because it executes all the code cells.
+> **WARNING:** Rendering the _labs_ takes several minutes because it executes all the code cells.
 
 ```
 bash scripts/render.sh [seurat|bioc|scanpy|spatial|site|compile|all]
 ```
 
-If you made changes to only selected labs, you can render them individually by running with the following commands:
+If you made changes to only selected labs, you can render them individually as shwon below:
 
 ```
 # r/seurat
@@ -96,7 +99,7 @@ docker run --rm -ti --platform=linux/amd64 -u 1000:1000 -v ${PWD}:/home/jovyan/w
 docker run --rm -ti --platform=linux/amd64 -u 1000:1000 -v ${PWD}:/work --entrypoint /opt/conda/bin/conda ghcr.io/nbisweden/workshop-scrnaseq-scanpy:20250325-2256 run -u scanpy quarto render /work/labs/scanpy/scanpy_<lab_name>.qmd
 ```
 
-Successfully rendered outputs are moved to `docs/_site` folder and chunks are cached under `docs/_freeze`. These folders are gitignored.
+Successfully rendered outputs are moved to the `docs/_site` folder and chunks are cached under `docs/_freeze`. These folders are gitignored.
 
 ### Publish site
 
@@ -105,8 +108,9 @@ The site content to be published is in `docs/_site`. Verify the content locally 
   cd docs/_site
   python3 -m http.server 8000
   ```
+and in the browser, navigate to `localhost:8000`.
 
-> **IMPORTANT:** `quarto publish` _erases_ the content of `gh-pages` branch and it replaces with the content of `docs/_site` folder. Make sure you updated it as described in the [suggested workflow](#suggested-workflow). In particular, double-check that the `archive/` folder is synced.
+> **IMPORTANT:** `quarto publish` _erases_ the content of `gh-pages` branch and replaces it with the content of `docs/_site` folder. Make sure you updated it as described in the [suggested workflow](#suggested-workflow). In particular, double-check that the `archive/` folder is synced.
 
 To serve the site from the feature branch, run
   ```sh

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,63 @@
+## Contributing
+
+To add or update contents of this repo, first clone the repo, create a new branch, make changes/updates as needed, stage the changes, commit it and push the new branch to GitHub. Then, on GitHub, send a pull request to master.
+
+```
+git clone --depth 1 --single-branch --branch master https://github.com/nbisweden/workshop-scrnaseq.git
+git checkout -b <branch-name>
+
+# make your changes
+
+git add <changed_files>
+git commit -m "short descriptive message"
+git push -u origin <branch_name>
+```
+
+The labs use Quarto's _shortcodes_ for templating, with metadata located in `docs/labs/_metadata.yml`. These are snippets of text identified by a _tag_ of the form `{{< meta >}}` and allow to insert the same content to the different toolkits. The lab templates are stored in `docs/labs/<toolkit>`. To get the final version of the labs you need to compile the labs and the results are stored in `compiled/labs/<toolkit>`.
+
+To make changes to the labs, the workflow is as follows:
+- Add/modify metedata snippets.
+- Add the new snippet tag to all labs in `docs/labs`.
+- Add/modify code blocks in all toolkits.
+- Compile labs.
+- Test your changes.
+
+Once all changes are tested, you need to render the site. This step takes `.qmd` files and renders `.html` files for the site. The site is located in `docs/_site`.
+
+## Compile labs
+
+To compile all `.qmd` into `compiled/labs` as `.qmd` and `.ipynb` with evaluated meta variables, can be run directly with the compile script using:
+
+```
+bash scripts/compile.sh [seurat|bioc|scanpy|all]
+```
+
+## Render site
+
+To render all `.qmd` files (site files and labs) in the repo to `docs/_site` as `.html` output, run the command below, choosing the corresponding argument, depending on your changes.
+
+> **WARNING:** Rendering the labs takes several minutes because it executes all the code cells.
+
+```
+bash scripts/render.sh [seurat|bioc|scanpy|spatial|site|compile|all]
+```
+
+If you made changes to only selected labs, you can render them individually by running with the following commands:
+
+```
+# r/seurat
+docker run --rm -ti --platform=linux/amd64 -u 1000:1000 -v ${PWD}:/home/jovyan/work --entrypoint /usr/local/conda/bin/conda ghcr.io/nbisweden/workshop-scrnaseq-seurat:20250320-2311 run -n seurat quarto render /home/jovyan/work/docs/labs/seurat/seurat_<lab_name>.qmd
+
+# r/bioc
+docker run --rm -ti --platform=linux/amd64 -u 1000:1000 -v ${PWD}:/home/jovyan/work --entrypoint /usr/local/conda/bin/conda ghcr.io/nbisweden/workshop-scrnaseq-seurat:20250320-2311 run -n seurat quarto render /home/jovyan/work/docs/labs/bioc/bioc_<lab_name>.qmd
+
+# python/scanpy
+docker run --rm -ti --platform=linux/amd64 -u 1000:1000 -v ${PWD}:/work --entrypoint /opt/conda/bin/conda ghcr.io/nbisweden/workshop-scrnaseq-scanpy:20250325-2256 run -u scanpy quarto render /work/labs/scanpy/scanpy_<lab_name>.qmd
+```
+
+Successfully rendered outputs are moved to `docs/_site` folder and chunks are cached under `docs/_freeze`. These folders are gitignored.
+
+## Publish site
+
+TBA
+

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-## Contributing
+# Contributing
 
 To add or update contents of this repo, first clone the repo, create a new branch, make changes/updates as needed, stage the changes, commit it and push the new branch to GitHub. Then, on GitHub, send a pull request to master.
 
@@ -22,9 +22,50 @@ To make changes to the labs, the workflow is as follows:
 - Compile labs.
 - Test your changes.
 
-Once all changes are tested, you need to render the site. This step takes `.qmd` files and renders `.html` files for the site. The site is located in `docs/_site`.
+Once all changes are tested, you need to [render the site](#render-site). This step takes `.qmd` files and renders `.html` files for the site. The site is located in `docs/_site`.
 
-## Compile labs
+> **IMPORTANT:** Before rendering any files, make sure `docs/_site` is synced with the contents of `gh-pages` branch. See [site](#site) section for more details.
+
+## Site
+
+This section contains guidelines on how to make changes to site-related files (_i.e._ `compiled/` and `docs/` folders). Read first the [suggested workflow](#suggested-workflow) section.
+
+> **IMPORTANT:** If you made changes to the labs (`docs/labs`) you need to [compile the labs](#compile-labs) first.
+
+### Suggested workflow
+
+- Make sure your feature branch is clean (no uncommited changes).
+- Switch to `gh-pages` branch and run `git pull` to make sure it is up to date.
+- Switch back to the feature branch.
+- If you don't have a folder `docs/_site` you should create one.
+  ```sh
+  mkdir docs/_site
+  ```
+- If you already have a folder `docs/_site`, remove all its content (but not the folder itself).
+  ```sh
+  rm -rf docs/_site/*
+  ```
+- Update the folder `docs/_site` with the content of `gh-pages` branch.
+  ```sh
+  git archive gh-pages | tar -x -C docs/_site
+  ```
+- Verify that `docs/_site` on your feature branch is now up to date.
+- [Render](#render-site) any code files that were changed.
+- Serve the site locally and check the changes
+  ```sh
+  cd docs/_site
+  python3 -m http.server 8000
+  ```
+- To serve the site from the feature branch (make sure the content is what you intend)
+  ```sh
+  cd docs
+  quarto publish gh-pages --no-render
+  ```
+- You can follow the same procedure from `master` after you merged your feature branch.
+
+- **IMPORTANT:** This workflow works with `archive` as well, since we tar the `gh-pages` branch content, and as long as `gh-pages:archive` folder exists, it will be included in the tar, and copied to `docs/_site`. Rendering will not interfere with this folder.
+
+### Compile labs
 
 To compile all `.qmd` into `compiled/labs` as `.qmd` and `.ipynb` with evaluated meta variables, can be run directly with the compile script using:
 
@@ -32,7 +73,7 @@ To compile all `.qmd` into `compiled/labs` as `.qmd` and `.ipynb` with evaluated
 bash scripts/compile.sh [seurat|bioc|scanpy|all]
 ```
 
-## Render site
+### Render site
 
 To render all `.qmd` files (site files and labs) in the repo to `docs/_site` as `.html` output, run the command below, choosing the corresponding argument, depending on your changes.
 
@@ -57,7 +98,19 @@ docker run --rm -ti --platform=linux/amd64 -u 1000:1000 -v ${PWD}:/work --entryp
 
 Successfully rendered outputs are moved to `docs/_site` folder and chunks are cached under `docs/_freeze`. These folders are gitignored.
 
-## Publish site
+### Publish site
 
-TBA
+The site content to be published is in `docs/_site`. Verify the content locally by running
+  ```sh
+  cd docs/_site
+  python3 -m http.server 8000
+  ```
+
+> **IMPORTANT:** `quarto publish` _erases_ the content of `gh-pages` branch and it replaces with the content of `docs/_site` folder. Make sure you updated it as described in the [suggested workflow](#suggested-workflow). In particular, double-check that the `archive/` folder is synced.
+
+To serve the site from the feature branch, run
+  ```sh
+  cd docs
+  quarto publish gh-pages --no-render
+  ```
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,395 @@
+Attribution 4.0 International
+
+=======================================================================
+
+Creative Commons Corporation ("Creative Commons") is not a law firm and
+does not provide legal services or legal advice. Distribution of
+Creative Commons public licenses does not create a lawyer-client or
+other relationship. Creative Commons makes its licenses and related
+information available on an "as-is" basis. Creative Commons gives no
+warranties regarding its licenses, any material licensed under their
+terms and conditions, or any related information. Creative Commons
+disclaims all liability for damages resulting from their use to the
+fullest extent possible.
+
+Using Creative Commons Public Licenses
+
+Creative Commons public licenses provide a standard set of terms and
+conditions that creators and other rights holders may use to share
+original works of authorship and other material subject to copyright
+and certain other rights specified in the public license below. The
+following considerations are for informational purposes only, are not
+exhaustive, and do not form part of our licenses.
+
+     Considerations for licensors: Our public licenses are
+     intended for use by those authorized to give the public
+     permission to use material in ways otherwise restricted by
+     copyright and certain other rights. Our licenses are
+     irrevocable. Licensors should read and understand the terms
+     and conditions of the license they choose before applying it.
+     Licensors should also secure all rights necessary before
+     applying our licenses so that the public can reuse the
+     material as expected. Licensors should clearly mark any
+     material not subject to the license. This includes other CC-
+     licensed material, or material used under an exception or
+     limitation to copyright. More considerations for licensors:
+    wiki.creativecommons.org/Considerations_for_licensors
+
+     Considerations for the public: By using one of our public
+     licenses, a licensor grants the public permission to use the
+     licensed material under specified terms and conditions. If
+     the licensor's permission is not necessary for any reason--for
+     example, because of any applicable exception or limitation to
+     copyright--then that use is not regulated by the license. Our
+     licenses grant only permissions under copyright and certain
+     other rights that a licensor has authority to grant. Use of
+     the licensed material may still be restricted for other
+     reasons, including because others have copyright or other
+     rights in the material. A licensor may make special requests,
+     such as asking that all changes be marked or described.
+     Although not required by our licenses, you are encouraged to
+     respect those requests where reasonable. More considerations
+     for the public:
+    wiki.creativecommons.org/Considerations_for_licensees
+
+=======================================================================
+
+Creative Commons Attribution 4.0 International Public License
+
+By exercising the Licensed Rights (defined below), You accept and agree
+to be bound by the terms and conditions of this Creative Commons
+Attribution 4.0 International Public License ("Public License"). To the
+extent this Public License may be interpreted as a contract, You are
+granted the Licensed Rights in consideration of Your acceptance of
+these terms and conditions, and the Licensor grants You such rights in
+consideration of benefits the Licensor receives from making the
+Licensed Material available under these terms and conditions.
+
+
+Section 1 -- Definitions.
+
+  a. Adapted Material means material subject to Copyright and Similar
+     Rights that is derived from or based upon the Licensed Material
+     and in which the Licensed Material is translated, altered,
+     arranged, transformed, or otherwise modified in a manner requiring
+     permission under the Copyright and Similar Rights held by the
+     Licensor. For purposes of this Public License, where the Licensed
+     Material is a musical work, performance, or sound recording,
+     Adapted Material is always produced where the Licensed Material is
+     synched in timed relation with a moving image.
+
+  b. Adapter's License means the license You apply to Your Copyright
+     and Similar Rights in Your contributions to Adapted Material in
+     accordance with the terms and conditions of this Public License.
+
+  c. Copyright and Similar Rights means copyright and/or similar rights
+     closely related to copyright including, without limitation,
+     performance, broadcast, sound recording, and Sui Generis Database
+     Rights, without regard to how the rights are labeled or
+     categorized. For purposes of this Public License, the rights
+     specified in Section 2(b)(1)-(2) are not Copyright and Similar
+     Rights.
+
+  d. Effective Technological Measures means those measures that, in the
+     absence of proper authority, may not be circumvented under laws
+     fulfilling obligations under Article 11 of the WIPO Copyright
+     Treaty adopted on December 20, 1996, and/or similar international
+     agreements.
+
+  e. Exceptions and Limitations means fair use, fair dealing, and/or
+     any other exception or limitation to Copyright and Similar Rights
+     that applies to Your use of the Licensed Material.
+
+  f. Licensed Material means the artistic or literary work, database,
+     or other material to which the Licensor applied this Public
+     License.
+
+  g. Licensed Rights means the rights granted to You subject to the
+     terms and conditions of this Public License, which are limited to
+     all Copyright and Similar Rights that apply to Your use of the
+     Licensed Material and that the Licensor has authority to license.
+
+  h. Licensor means the individual(s) or entity(ies) granting rights
+     under this Public License.
+
+  i. Share means to provide material to the public by any means or
+     process that requires permission under the Licensed Rights, such
+     as reproduction, public display, public performance, distribution,
+     dissemination, communication, or importation, and to make material
+     available to the public including in ways that members of the
+     public may access the material from a place and at a time
+     individually chosen by them.
+
+  j. Sui Generis Database Rights means rights other than copyright
+     resulting from Directive 96/9/EC of the European Parliament and of
+     the Council of 11 March 1996 on the legal protection of databases,
+     as amended and/or succeeded, as well as other essentially
+     equivalent rights anywhere in the world.
+
+  k. You means the individual or entity exercising the Licensed Rights
+     under this Public License. Your has a corresponding meaning.
+
+
+Section 2 -- Scope.
+
+  a. License grant.
+
+       1. Subject to the terms and conditions of this Public License,
+          the Licensor hereby grants You a worldwide, royalty-free,
+          non-sublicensable, non-exclusive, irrevocable license to
+          exercise the Licensed Rights in the Licensed Material to:
+
+            a. reproduce and Share the Licensed Material, in whole or
+               in part; and
+
+            b. produce, reproduce, and Share Adapted Material.
+
+       2. Exceptions and Limitations. For the avoidance of doubt, where
+          Exceptions and Limitations apply to Your use, this Public
+          License does not apply, and You do not need to comply with
+          its terms and conditions.
+
+       3. Term. The term of this Public License is specified in Section
+          6(a).
+
+       4. Media and formats; technical modifications allowed. The
+          Licensor authorizes You to exercise the Licensed Rights in
+          all media and formats whether now known or hereafter created,
+          and to make technical modifications necessary to do so. The
+          Licensor waives and/or agrees not to assert any right or
+          authority to forbid You from making technical modifications
+          necessary to exercise the Licensed Rights, including
+          technical modifications necessary to circumvent Effective
+          Technological Measures. For purposes of this Public License,
+          simply making modifications authorized by this Section 2(a)
+          (4) never produces Adapted Material.
+
+       5. Downstream recipients.
+
+            a. Offer from the Licensor -- Licensed Material. Every
+               recipient of the Licensed Material automatically
+               receives an offer from the Licensor to exercise the
+               Licensed Rights under the terms and conditions of this
+               Public License.
+
+            b. No downstream restrictions. You may not offer or impose
+               any additional or different terms or conditions on, or
+               apply any Effective Technological Measures to, the
+               Licensed Material if doing so restricts exercise of the
+               Licensed Rights by any recipient of the Licensed
+               Material.
+
+       6. No endorsement. Nothing in this Public License constitutes or
+          may be construed as permission to assert or imply that You
+          are, or that Your use of the Licensed Material is, connected
+          with, or sponsored, endorsed, or granted official status by,
+          the Licensor or others designated to receive attribution as
+          provided in Section 3(a)(1)(A)(i).
+
+  b. Other rights.
+
+       1. Moral rights, such as the right of integrity, are not
+          licensed under this Public License, nor are publicity,
+          privacy, and/or other similar personality rights; however, to
+          the extent possible, the Licensor waives and/or agrees not to
+          assert any such rights held by the Licensor to the limited
+          extent necessary to allow You to exercise the Licensed
+          Rights, but not otherwise.
+
+       2. Patent and trademark rights are not licensed under this
+          Public License.
+
+       3. To the extent possible, the Licensor waives any right to
+          collect royalties from You for the exercise of the Licensed
+          Rights, whether directly or through a collecting society
+          under any voluntary or waivable statutory or compulsory
+          licensing scheme. In all other cases the Licensor expressly
+          reserves any right to collect such royalties.
+
+
+Section 3 -- License Conditions.
+
+Your exercise of the Licensed Rights is expressly made subject to the
+following conditions.
+
+  a. Attribution.
+
+       1. If You Share the Licensed Material (including in modified
+          form), You must:
+
+            a. retain the following if it is supplied by the Licensor
+               with the Licensed Material:
+
+                 i. identification of the creator(s) of the Licensed
+                    Material and any others designated to receive
+                    attribution, in any reasonable manner requested by
+                    the Licensor (including by pseudonym if
+                    designated);
+
+                ii. a copyright notice;
+
+               iii. a notice that refers to this Public License;
+
+                iv. a notice that refers to the disclaimer of
+                    warranties;
+
+                 v. a URI or hyperlink to the Licensed Material to the
+                    extent reasonably practicable;
+
+            b. indicate if You modified the Licensed Material and
+               retain an indication of any previous modifications; and
+
+            c. indicate the Licensed Material is licensed under this
+               Public License, and include the text of, or the URI or
+               hyperlink to, this Public License.
+
+       2. You may satisfy the conditions in Section 3(a)(1) in any
+          reasonable manner based on the medium, means, and context in
+          which You Share the Licensed Material. For example, it may be
+          reasonable to satisfy the conditions by providing a URI or
+          hyperlink to a resource that includes the required
+          information.
+
+       3. If requested by the Licensor, You must remove any of the
+          information required by Section 3(a)(1)(A) to the extent
+          reasonably practicable.
+
+       4. If You Share Adapted Material You produce, the Adapter's
+          License You apply must not prevent recipients of the Adapted
+          Material from complying with this Public License.
+
+
+Section 4 -- Sui Generis Database Rights.
+
+Where the Licensed Rights include Sui Generis Database Rights that
+apply to Your use of the Licensed Material:
+
+  a. for the avoidance of doubt, Section 2(a)(1) grants You the right
+     to extract, reuse, reproduce, and Share all or a substantial
+     portion of the contents of the database;
+
+  b. if You include all or a substantial portion of the database
+     contents in a database in which You have Sui Generis Database
+     Rights, then the database in which You have Sui Generis Database
+     Rights (but not its individual contents) is Adapted Material; and
+
+  c. You must comply with the conditions in Section 3(a) if You Share
+     all or a substantial portion of the contents of the database.
+
+For the avoidance of doubt, this Section 4 supplements and does not
+replace Your obligations under this Public License where the Licensed
+Rights include other Copyright and Similar Rights.
+
+
+Section 5 -- Disclaimer of Warranties and Limitation of Liability.
+
+  a. UNLESS OTHERWISE SEPARATELY UNDERTAKEN BY THE LICENSOR, TO THE
+     EXTENT POSSIBLE, THE LICENSOR OFFERS THE LICENSED MATERIAL AS-IS
+     AND AS-AVAILABLE, AND MAKES NO REPRESENTATIONS OR WARRANTIES OF
+     ANY KIND CONCERNING THE LICENSED MATERIAL, WHETHER EXPRESS,
+     IMPLIED, STATUTORY, OR OTHER. THIS INCLUDES, WITHOUT LIMITATION,
+     WARRANTIES OF TITLE, MERCHANTABILITY, FITNESS FOR A PARTICULAR
+     PURPOSE, NON-INFRINGEMENT, ABSENCE OF LATENT OR OTHER DEFECTS,
+     ACCURACY, OR THE PRESENCE OR ABSENCE OF ERRORS, WHETHER OR NOT
+     KNOWN OR DISCOVERABLE. WHERE DISCLAIMERS OF WARRANTIES ARE NOT
+     ALLOWED IN FULL OR IN PART, THIS DISCLAIMER MAY NOT APPLY TO YOU.
+
+  b. TO THE EXTENT POSSIBLE, IN NO EVENT WILL THE LICENSOR BE LIABLE
+     TO YOU ON ANY LEGAL THEORY (INCLUDING, WITHOUT LIMITATION,
+     NEGLIGENCE) OR OTHERWISE FOR ANY DIRECT, SPECIAL, INDIRECT,
+     INCIDENTAL, CONSEQUENTIAL, PUNITIVE, EXEMPLARY, OR OTHER LOSSES,
+     COSTS, EXPENSES, OR DAMAGES ARISING OUT OF THIS PUBLIC LICENSE OR
+     USE OF THE LICENSED MATERIAL, EVEN IF THE LICENSOR HAS BEEN
+     ADVISED OF THE POSSIBILITY OF SUCH LOSSES, COSTS, EXPENSES, OR
+     DAMAGES. WHERE A LIMITATION OF LIABILITY IS NOT ALLOWED IN FULL OR
+     IN PART, THIS LIMITATION MAY NOT APPLY TO YOU.
+
+  c. The disclaimer of warranties and limitation of liability provided
+     above shall be interpreted in a manner that, to the extent
+     possible, most closely approximates an absolute disclaimer and
+     waiver of all liability.
+
+
+Section 6 -- Term and Termination.
+
+  a. This Public License applies for the term of the Copyright and
+     Similar Rights licensed here. However, if You fail to comply with
+     this Public License, then Your rights under this Public License
+     terminate automatically.
+
+  b. Where Your right to use the Licensed Material has terminated under
+     Section 6(a), it reinstates:
+
+       1. automatically as of the date the violation is cured, provided
+          it is cured within 30 days of Your discovery of the
+          violation; or
+
+       2. upon express reinstatement by the Licensor.
+
+     For the avoidance of doubt, this Section 6(b) does not affect any
+     right the Licensor may have to seek remedies for Your violations
+     of this Public License.
+
+  c. For the avoidance of doubt, the Licensor may also offer the
+     Licensed Material under separate terms or conditions or stop
+     distributing the Licensed Material at any time; however, doing so
+     will not terminate this Public License.
+
+  d. Sections 1, 5, 6, 7, and 8 survive termination of this Public
+     License.
+
+
+Section 7 -- Other Terms and Conditions.
+
+  a. The Licensor shall not be bound by any additional or different
+     terms or conditions communicated by You unless expressly agreed.
+
+  b. Any arrangements, understandings, or agreements regarding the
+     Licensed Material not stated herein are separate from and
+     independent of the terms and conditions of this Public License.
+
+
+Section 8 -- Interpretation.
+
+  a. For the avoidance of doubt, this Public License does not, and
+     shall not be interpreted to, reduce, limit, restrict, or impose
+     conditions on any use of the Licensed Material that could lawfully
+     be made without permission under this Public License.
+
+  b. To the extent possible, if any provision of this Public License is
+     deemed unenforceable, it shall be automatically reformed to the
+     minimum extent necessary to make it enforceable. If the provision
+     cannot be reformed, it shall be severed from this Public License
+     without affecting the enforceability of the remaining terms and
+     conditions.
+
+  c. No term or condition of this Public License will be waived and no
+     failure to comply consented to unless expressly agreed to by the
+     Licensor.
+
+  d. Nothing in this Public License constitutes or may be interpreted
+     as a limitation upon, or waiver of, any privileges and immunities
+     that apply to the Licensor or You, including from the legal
+     processes of any jurisdiction or authority.
+
+
+=======================================================================
+
+Creative Commons is not a party to its public
+licenses. Notwithstanding, Creative Commons may elect to apply one of
+its public licenses to material it publishes and in those instances
+will be considered the “Licensor.” The text of the Creative Commons
+public licenses is dedicated to the public domain under the CC0 Public
+Domain Dedication. Except for the limited purpose of indicating that
+material is shared under a Creative Commons public license or as
+otherwise permitted by the Creative Commons policies published at
+creativecommons.org/policies, Creative Commons does not authorize the
+use of the trademark "Creative Commons" or any other trademark or logo
+of Creative Commons without its prior written consent including,
+without limitation, in connection with any unauthorized modifications
+to any of its public licenses or any other arrangements,
+understandings, or agreements concerning use of licensed material. For
+the avoidance of doubt, this paragraph does not form part of the
+public licenses.
+
+Creative Commons may be contacted at creativecommons.org.

--- a/README.md
+++ b/README.md
@@ -4,18 +4,6 @@
 
 This repo contains the course material for NBIS workshop **Single Cell RNA-Seq Data Analyses**. The rendered view of this repo is available [here](https://nbisweden.github.io/workshop-scRNAseq/).
 
-## Contributing
-
-To add or update contents of this repo (for collaborators), first clone the repo, create a new branch, make changes/updates as needed, stage the changes, commit it and push the new branch to GitHub. Then, on GitHub, send a pull request to master.
-
-```
-git clone --depth 1 --single-branch --branch master https://github.com/nbisweden/workshop-scrnaseq.git
-git checkout -b <branch-name>
-git add .
-git commit -m "I did this and that"
-git push -u origin <branch_name>
-```
-
 ## Environment
 
 ```
@@ -72,50 +60,6 @@ conda activate scanpy
 
 # for scanpy
 ~/work/download-labs.sh "https://github.com/NBISweden" "workshop-scRNAseq" "compiled/labs" "scanpy" "work/labs"
-```
-
-## Render labs
-
-Instructions to render the `.qmd` files to `.html`.
-
-- For Seurat labs
-
-```
-# r/seurat
-docker run --rm -ti --platform=linux/amd64 -u 1000:1000 -v ${PWD}:/work ghcr.io/nbisweden/workshop-scrnaseq-seurat:20250320-2311 quarto render /work/labs/seurat/seurat_01_qc.qmd
-
-# r/bioc
-docker run --rm -ti --platform=linux/amd64 -u 1000:1000 -v ${PWD}:/work ghcr.io/nbisweden/workshop-scrnaseq-seurat:20250320-2311 quarto render /work/labs/bioc/bioc_01_qc.qmd
-
-# python/scanpy
-docker run --rm -ti --platform=linux/amd64 -u 1000:1000 -v ${PWD}:/work ghcr.io/nbisweden/workshop-scrnaseq-scanpy:20250325-2256 quarto render /work/labs/scanpy/scanpy_01_qc.qmd
-```
-
-- Successfully rendered outputs are moved to `docs` folder and chunks are cached under `_freeze`.
-
-## Scripts
-
-To render all qmd files in the repo to `docs/` as html output, run
-
-```
-bash scripts/render.sh all
-```
-
-The `render.sh` script has options to render all of the docs/scripts that are needed, but also to render different parts. The options are:
-
-* all - run all the steps
-* seurat - render all seurat labs
-* bioc - render all bioc labs
-* scanpy - render all scanpy labs
-* spatial - render all 3 spatial labs.
-* site - render all site stuff like lectures, contents, schedule etc.
-* compile - compile labs into Rmd/ipynb
-
-
-To compile all qmds into `compiled/labs` as qmds and ipynb with evaluated meta variables, can also be run directly with the compile script using:
-
-```
-bash scripts/compile.sh
 ```
 
 ---

--- a/docs/_quarto.yml
+++ b/docs/_quarto.yml
@@ -49,7 +49,7 @@ website:
     border: false
     left: "{{< meta current_year >}} [NBIS](https://nbis.se) | [GPL-3 License](https://choosealicense.com/licenses/gpl-3.0/)"
     right: "Published with [Quarto](https://quarto.org/) v{{< meta quarto_version >}}"
-  site-url: "https://nbisweden.github.io/workshop-scrnaseq/"
+  site-url: "https://nbisweden.github.io/workshop-scRNAseq/"
 
 format:
   html:

--- a/scripts/render.sh
+++ b/scripts/render.sh
@@ -109,7 +109,11 @@ render_files_spatial() {
 }
 
 render_files_lectures() {
-    local lecture_files=("$LECTURE_DIR/gsa/index.qmd")
+    local lecture_files=(
+        # dge requires ggpubr so this is currently being rendered interactively. ggpubr should be added to the container for next year
+        # "$LECTURE_DIR/dge/index.qmd"
+        "$LECTURE_DIR/gsa/index.qmd"
+    )
     local start
     start=$(timer_start)
     for file in "${lecture_files[@]}"; do

--- a/scripts/render.sh
+++ b/scripts/render.sh
@@ -57,7 +57,7 @@ render_files_r() {
     start=$(timer_start)
     for file in "${files[@]}"; do
         echo "Rendering $file ..."
-        docker run --rm -it --platform=linux/amd64 -u root -v "${PWD}:/home/jovyan/work" \
+        docker run --rm -it --platform=linux/amd64 -u 1000:1000 -v "${PWD}:/home/jovyan/work" \
             --entrypoint "$ENTRYPOINT_R" "$DOCKER_R" run -n seurat quarto render "/home/jovyan/work/$file"
     done
     timer_report "$start"


### PR DESCRIPTION
This PR adds contributing guide and license.

It also fixes
- an old issue with the 404 page
- remove the DGE lecture from rendering until the issue with `ggpubr` dependency is fixed