### PR TITLE
docs/home_contents: fix download links

### DIFF
--- a/docs/home_contents.qmd
+++ b/docs/home_contents.qmd
@@ -45,13 +45,10 @@ The lectures from the 2025 course can be found on the [NBIS YouTube channel](htt
 
 Below are a few reports where the results from the 3 toolkits and multiple methods in the toolkits are analysed. *OBS!* Several of these scripts requires additional packages that are not available in the Docker containers used for the exercises.
 
-* General comparison of the main steps of the pipelines: [{{< fa file-lines >}}](labs/comparison/comparison_pipelines.html) [{{< fa download >}}](https://raw.githubusercontent.com/NBISweden/workshop-scRNAseq/master/labs/comparison/comparison_pipelines.qmd)
-* Comparison of Variable gene selection methods: [{{< fa file-lines >}}](labs/comparison/comparison_hvg.html) [{{< fa download >}}](https://raw.githubusercont\
-ent.com/NBISweden/workshop-scRNAseq/master/labs/comparison/comparison_hvg.qmd) 
-* Differential gene expression detection: [{{< fa file-lines >}}](labs/comparison/comparison_dge.html) [{{< fa download >}}](https://raw.githubusercont\
-ent.com/NBISweden/workshop-scRNAseq/master/labs/comparison/comparison_dge.qmd)
-* Normalization methods: [{{< fa file-lines >}}](labs/comparison/comparison_normalization.html) [{{< fa download >}}](https://raw.githubusercont\
-ent.com/NBISweden/workshop-scRNAseq/master/labs/comparison/comparison_normalization.qmd)
+* General comparison of the main steps of the pipelines: [{{< fa file-lines >}}](labs/comparison/comparison_pipelines.html) [{{< fa download >}}](https://raw.githubusercontent.com/NBISweden/workshop-scRNAseq/master/docs/labs/comparison/comparison_pipelines.qmd)
+* Comparison of Variable gene selection methods: [{{< fa file-lines >}}](labs/comparison/comparison_hvg.html) [{{< fa download >}}](https://raw.githubusercontent.com/NBISweden/workshop-scRNAseq/master/docs/labs/comparison/comparison_hvg.qmd) 
+* Differential gene expression detection: [{{< fa file-lines >}}](labs/comparison/comparison_dge.html) [{{< fa download >}}](https://raw.githubusercontent.com/NBISweden/workshop-scRNAseq/master/docs/labs/comparison/comparison_dge.qmd)
+* Normalization methods: [{{< fa file-lines >}}](labs/comparison/comparison_normalization.html) [{{< fa download >}}](https://raw.githubusercontent.com/NBISweden/workshop-scRNAseq/master/docs/labs/comparison/comparison_normalization.qmd)
 
 ## Previous course iterations
 


### PR DESCRIPTION
This PR fixes the links that were broken in `home_contents.qmd` file after the refactoring of the repo.