### PR TITLE
fix/docs: update container user

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -90,13 +90,13 @@ If you made changes to only selected labs, you can render them individually as s
 
 ```
 # r/seurat
-docker run --rm -ti --platform=linux/amd64 -u 1000:1000 -v ${PWD}:/home/jovyan/work --entrypoint /usr/local/conda/bin/conda ghcr.io/nbisweden/workshop-scrnaseq-seurat:20250320-2311 run -n seurat quarto render /home/jovyan/work/docs/labs/seurat/seurat_<lab_name>.qmd
+docker run --rm -ti --platform=linux/amd64 -u root -v ${PWD}:/home/jovyan/work --entrypoint /usr/local/conda/bin/conda ghcr.io/nbisweden/workshop-scrnaseq-seurat:20250320-2311 run -n seurat quarto render /home/jovyan/work/docs/labs/seurat/seurat_<lab_name>.qmd
 
 # r/bioc
-docker run --rm -ti --platform=linux/amd64 -u 1000:1000 -v ${PWD}:/home/jovyan/work --entrypoint /usr/local/conda/bin/conda ghcr.io/nbisweden/workshop-scrnaseq-seurat:20250320-2311 run -n seurat quarto render /home/jovyan/work/docs/labs/bioc/bioc_<lab_name>.qmd
+docker run --rm -ti --platform=linux/amd64 -u root -v ${PWD}:/home/jovyan/work --entrypoint /usr/local/conda/bin/conda ghcr.io/nbisweden/workshop-scrnaseq-seurat:20250320-2311 run -n seurat quarto render /home/jovyan/work/docs/labs/bioc/bioc_<lab_name>.qmd
 
 # python/scanpy
-docker run --rm -ti --platform=linux/amd64 -u 1000:1000 -v ${PWD}:/work --entrypoint /opt/conda/bin/conda ghcr.io/nbisweden/workshop-scrnaseq-scanpy:20250325-2256 run -u scanpy quarto render /work/labs/scanpy/scanpy_<lab_name>.qmd
+docker run --rm -ti --platform=linux/amd64 -u jovyan -v ${PWD}:/work --entrypoint /opt/conda/bin/conda ghcr.io/nbisweden/workshop-scrnaseq-scanpy:20250325-2256 run -u scanpy quarto render /work/labs/scanpy/scanpy_<lab_name>.qmd
 ```
 
 Successfully rendered outputs are moved to the `docs/_site` folder and chunks are cached under `docs/_freeze`. These folders are gitignored.

--- a/scripts/compile.sh
+++ b/scripts/compile.sh
@@ -47,7 +47,7 @@ check_output_dir() {
 # create compiled versions of qmd using profile "compiled"
 quarto_compile() {
     echo "Compiling $1 labs ..."
-    docker run --rm --platform=linux/amd64 -u 1000:1000 -v "${PWD}:/work" "$DOCKER_SITE" quarto render --profile compile "/work/$LAB_DIR/$1"/*.qmd --to markdown-header_attributes --metadata engine:markdown --log-level warning,error
+    docker run --rm --platform=linux/amd64 -u docker -v "${PWD}:/work" "$DOCKER_SITE" quarto render --profile compile "/work/$LAB_DIR/$1"/*.qmd --to markdown-header_attributes --metadata engine:markdown --log-level warning,error
 }
 
 # Read an md/qmd, remove unnecessary lines from yaml frontmatter
@@ -92,7 +92,7 @@ qmd_to_ipynb() {
     echo "Converting $1 .qmd files to .ipynb"
     shopt -s nullglob
     for file in "${OUTPUT_DIR}/labs/$1"/*.qmd; do
-        docker run --rm --platform=linux/amd64 -u 1000:1000 -v "${PWD}:/work" "$DOCKER_SITE" quarto convert "/work/${file}"
+        docker run --rm --platform=linux/amd64 -u docker -v "${PWD}:/work" "$DOCKER_SITE" quarto convert "/work/${file}"
         rm -f "$file"
     done
     shopt -u nullglob

--- a/scripts/render.sh
+++ b/scripts/render.sh
@@ -57,7 +57,7 @@ render_files_r() {
     start=$(timer_start)
     for file in "${files[@]}"; do
         echo "Rendering $file ..."
-        docker run --rm -it --platform=linux/amd64 -u 1000:1000 -v "${PWD}:/home/jovyan/work" \
+        docker run --rm -it --platform=linux/amd64 -u root -v "${PWD}:/home/jovyan/work" \
             --entrypoint "$ENTRYPOINT_R" "$DOCKER_R" run -n seurat quarto render "/home/jovyan/work/$file"
     done
     timer_report "$start"
@@ -69,7 +69,7 @@ render_files_scanpy() {
     start=$(timer_start)
     for file in "${files[@]}"; do
         echo "Rendering $file ..."
-        docker run --rm --platform=linux/amd64 -u 1000:1000 -v "${PWD}:/work" \
+        docker run --rm --platform=linux/amd64 -u jovyan -v "${PWD}:/work" \
             --entrypoint "$ENTRYPOINT_SCANPY" "$DOCKER_SCANPY" run -n scanpy quarto render "/work/$file"
     done
     timer_report "$start"
@@ -81,7 +81,7 @@ render_files_site() {
     start=$(timer_start)
     for file in "${files[@]}"; do
         echo "Rendering $file ..."
-        docker run --rm --platform=linux/amd64 -u 1000:1000 -v "${PWD}:/work" \
+        docker run --rm --platform=linux/amd64 -u docker -v "${PWD}:/work" \
             "$DOCKER_SITE" quarto render "/work/$file"
     done
     timer_report "$start"
@@ -97,13 +97,13 @@ render_files_spatial() {
     # local start
     # start=$(timer_start)
     # echo "Rendering $seurat_file ..."
-    # docker run --rm --platform=linux/amd64 -u 1000:1000 -v "${PWD}:/work" \
+    # docker run --rm --platform=linux/amd64 -u jovyan -v "${PWD}:/work" \
     #     "$DOCKER_SEURAT_SPATIAL" quarto render "/work/$seurat_file"
     # echo "Rendering $bioc_file ..."
-    # docker run --rm --platform=linux/amd64 -u 1000:1000 -v "${PWD}:/work" \
+    # docker run --rm --platform=linux/amd64 -u jovyan -v "${PWD}:/work" \
     #     "$DOCKER_BIOC_SPATIAL" quarto render "/work/$bioc_file"
     # echo "Rendering $scanpy_file ..."
-    # docker run --rm --platform=linux/amd64 -u 1000:1000 -v "${PWD}:/work" \
+    # docker run --rm --platform=linux/amd64 -u jovyan -v "${PWD}:/work" \
     #     --entrypoint "$ENTRYPOINT_SCANPY" "$DOCKER_SCANPY" run -n scanpy quarto render "/work/$scanpy_file"
     # timer_report "$start"
 }
@@ -118,7 +118,7 @@ render_files_lectures() {
     start=$(timer_start)
     for file in "${lecture_files[@]}"; do
         echo "Rendering $file ..."
-        docker run --rm -it --platform=linux/amd64 -v "${PWD}:/home/jovyan/work" \
+        docker run --rm -it --platform=linux/amd64 -u jovyan -v "${PWD}:/home/jovyan/work" \
             --entrypoint "$ENTRYPOINT_R" "$DOCKER_R" run -n seurat quarto render "/home/jovyan/work/$file"
     done
     timer_report "$start"


### PR DESCRIPTION
## Description

Container user was specified as `-u 1000:1000`. This was incorrect for two reasons:
- in some containers the group `1000` was not specified in `/etc/group` and was causing the container to print an error message.
- for the R container, it was crashing when rendering certain labs that needed to install packages from GitHub, because the conda environment location is not writable.

Note that when the R container was used to launch the RStudio server, installing from GitHub works. This is because RStudio creates an `R/` folder in `/home/jovyan` and packages are installed there.

## Changes

This PR updates the commands to use `-u root` when rendering R labs. It also updates the user from user id to user name, for consistency and readability.